### PR TITLE
Graphics pipeline creation

### DIFF
--- a/VulkanLearningAgain/VulkanLearningAgain.vcxproj
+++ b/VulkanLearningAgain/VulkanLearningAgain.vcxproj
@@ -94,7 +94,7 @@
     <PreBuildEvent>
       <Command>if not exist "$(ProjectDir)spr-v-c" mkdir "$(ProjectDir)spr-v-c"
 "$(Vulkan_SDK)\bin\glslc.exe" -fshader-stage=vertex -mfmt=c "$(ProjectDir)simpleVertex.glsl" -o "$(ProjectDir)spr-v-c\simpleVertex.spv"
-"$(Vulkan_SDK)\bin\glslc.exe" -fshader-stage=vertex -mfmt=c "$(ProjectDir)simpleFragment.glsl" -o "$(ProjectDir)spr-v-c\simpleFragment.spv"</Command>
+"$(Vulkan_SDK)\bin\glslc.exe" -fshader-stage=fragment -mfmt=c "$(ProjectDir)simpleFragment.glsl" -o "$(ProjectDir)spr-v-c\simpleFragment.spv"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -118,7 +118,7 @@
     <PreBuildEvent>
       <Command>if not exist "$(ProjectDir)spr-v-c" mkdir "$(ProjectDir)spr-v-c"
 "$(Vulkan_SDK)\bin\glslc.exe" -fshader-stage=vertex -mfmt=c "$(ProjectDir)simpleVertex.glsl" -o "$(ProjectDir)spr-v-c\simpleVertex.spv"
-"$(Vulkan_SDK)\bin\glslc.exe" -fshader-stage=vertex -mfmt=c "$(ProjectDir)simpleFragment.glsl" -o "$(ProjectDir)spr-v-c\simpleFragment.spv"</Command>
+"$(Vulkan_SDK)\bin\glslc.exe" -fshader-stage=fragment -mfmt=c "$(ProjectDir)simpleFragment.glsl" -o "$(ProjectDir)spr-v-c\simpleFragment.spv"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -146,7 +146,7 @@
     <PreBuildEvent>
       <Command>if not exist "$(ProjectDir)spr-v-c" mkdir "$(ProjectDir)spr-v-c"
 "$(Vulkan_SDK)\bin\glslc.exe" -fshader-stage=vertex -mfmt=c "$(ProjectDir)simpleVertex.glsl" -o "$(ProjectDir)spr-v-c\simpleVertex.spv"
-"$(Vulkan_SDK)\bin\glslc.exe" -fshader-stage=vertex -mfmt=c "$(ProjectDir)simpleFragment.glsl" -o "$(ProjectDir)spr-v-c\simpleFragment.spv"</Command>
+"$(Vulkan_SDK)\bin\glslc.exe" -fshader-stage=fragment -mfmt=c "$(ProjectDir)simpleFragment.glsl" -o "$(ProjectDir)spr-v-c\simpleFragment.spv"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -174,7 +174,7 @@
     <PreBuildEvent>
       <Command>if not exist "$(ProjectDir)spr-v-c" mkdir "$(ProjectDir)spr-v-c"
 "$(Vulkan_SDK)\bin\glslc.exe" -fshader-stage=vertex -mfmt=c "$(ProjectDir)simpleVertex.glsl" -o "$(ProjectDir)spr-v-c\simpleVertex.spv"
-"$(Vulkan_SDK)\bin\glslc.exe" -fshader-stage=vertex -mfmt=c "$(ProjectDir)simpleFragment.glsl" -o "$(ProjectDir)spr-v-c\simpleFragment.spv"</Command>
+"$(Vulkan_SDK)\bin\glslc.exe" -fshader-stage=fragment -mfmt=c "$(ProjectDir)simpleFragment.glsl" -o "$(ProjectDir)spr-v-c\simpleFragment.spv"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/VulkanLearningAgain/vulkanEngine.h
+++ b/VulkanLearningAgain/vulkanEngine.h
@@ -29,6 +29,11 @@ class VulkanEngine
 	VkShaderModule simpleVertexShaderModule;
 	VkShaderModule simpleFragmentShaderModule;
 	VkRenderPass simpleRenderPass;
+	VkDescriptorSetLayout simpleDescriptorSetLayout;
+	VkPipelineLayout simplePipelineLayout;
+	VkPipelineCache pipelineCache;
+	VkPipeline simpleGraphicsPipeline;
+	VkDebugUtilsMessengerEXT debugUtilsMessenger; // (added cause the driver threw nullptr expressions =) )
 
 	void createInstance(SDL_Window *sdlWindow);
 	void createDevices(void);
@@ -36,6 +41,7 @@ class VulkanEngine
 	void createSurface(SDL_Window *sdlWindow);
 	void createSwapchain(uint32_t width, uint32_t height);
 	void createRenderPass(void);
+	void createGraphicsPipelineLayout(void);
 	void createGraphicsPipeline(void);
 
 	struct SimpleVertex


### PR DESCRIPTION
Add the graphics pipeline creation. 

This branch was originally created because I was running into a nullptr exception when finally creating the graphics pipeline. I had previously misunderstood just how much of the error checking was being done exclusively in the validation layers so I hadn't set them up before. Now they can be optionally turned on by switching the ENABLE_VALIDATION pre-processor definition to 1. Enabling this revealed numerous bugs that have now been fixed.